### PR TITLE
Update schema.js

### DIFF
--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -43,7 +43,7 @@ export default ({
   properties: {
     manifest_version: {
       type: 'number',
-      enum: [2],
+      enum: [2, 3],
     },
     name: {type: 'string'},
     version: {


### PR DESCRIPTION
The latest manifest version in chrome is 3. If this is not specified properly, "host_permissions" are not accepted by chrome.
Here's an announcement post: https://developer.chrome.com/docs/extensions/mv3/intro/

# ↪️ Pull Request
This is a minimal change to allow specifying "3" as the manifest version in web extensions

## 🚨 Test instructions

I didn't find any existing unit tests for the webextension transformer. Please excuse me if this is a mistake, but I'm proposing this minimal change without test coverage.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
